### PR TITLE
docs(readme): standardize 5-badge set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ZeroAlloc.StateMachine
 
+[![NuGet](https://img.shields.io/nuget/v/ZeroAlloc.StateMachine.svg)](https://www.nuget.org/packages/ZeroAlloc.StateMachine)
+[![Build](https://github.com/ZeroAlloc-Net/ZeroAlloc.StateMachine/actions/workflows/ci.yml/badge.svg)](https://github.com/ZeroAlloc-Net/ZeroAlloc.StateMachine/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![AOT](https://img.shields.io/badge/AOT--Compatible-passing-brightgreen)](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/MarcelRoozekrans?style=flat&logo=githubsponsors&color=ea4aaa&label=Sponsor)](https://github.com/sponsors/MarcelRoozekrans)
-
 
 Source-generated, zero-allocation finite state machines for .NET.
 
 Add `[StateMachine]` and `[Transition<TState, TTrigger>]` attributes to a `partial` class or struct. A Roslyn source generator emits a `TryFire(TTrigger)` method as a `switch` expression over `(TState, TTrigger)` tuples — no dictionary, no delegate dispatch, no heap allocation on the transition path. AOT-safe.
-
-[![NuGet](https://img.shields.io/nuget/v/ZeroAlloc.StateMachine.svg)](https://www.nuget.org/packages/ZeroAlloc.StateMachine)
-[![Build](https://github.com/ZeroAlloc-Net/ZeroAlloc.StateMachine/actions/workflows/ci.yml/badge.svg)](https://github.com/ZeroAlloc-Net/ZeroAlloc.StateMachine/actions)
 
 ---
 


### PR DESCRIPTION
## Summary
Apply the canonical 5-badge set across all ZeroAlloc repos for visual consistency.

The set:
1. **NuGet version** — current published version of the primary package
2. **Build** — CI status (workflows/ci.yml)
3. **License: MIT** — yellow shields standard
4. **AOT-Compatible** — every ZeroAlloc package is AOT-safe; the badge advertises this consistently (new addition; no repo had one previously)
5. **GitHub Sponsors** — community support badge

## Background
Audit revealed 5 distinct badge profiles across 21 repos: ranging from 1 badge (EventSourcing, AsyncEvents) to 5 (Pipeline, Specification per-package), with inconsistent license colors, broken Build URLs, and non-standard `<img>` tags in some places. This PR aligns to a single canonical set.

Build URL pointed at `/actions` (broken) — corrected to `/actions/workflows/ci.yml`. License and AOT badges added; badges grouped at top per canonical layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)