### PR TITLE
fix: stop publishing broken stand-alone generator nupkg

### DIFF
--- a/src/ZeroAlloc.StateMachine.Generator/ZeroAlloc.StateMachine.Generator.csproj
+++ b/src/ZeroAlloc.StateMachine.Generator/ZeroAlloc.StateMachine.Generator.csproj
@@ -9,6 +9,13 @@
     <Description>Source generator for ZeroAlloc.StateMachine. Consumed automatically via ZeroAlloc.StateMachine.</Description>
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <!--
+      The generator is bundled into ZeroAlloc.StateMachine's NuGet package via the
+      IncludeGeneratorInPackage target in the main library's csproj. Publishing a
+      separate ZeroAlloc.StateMachine.Generator package would just produce a broken
+      stand-alone nupkg (DLL under lib/, not analyzers/), so suppress packing here.
+    -->
+    <IsPackable>false</IsPackable>
     <!-- Suppress RS2008: we use custom DiagnosticDescriptors with SupportedDiagnostics -->
     <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
The generator is already bundled into `ZeroAlloc.StateMachine`'s NuGet package via the `IncludeGeneratorInPackage` target in the main library's csproj. The generator project's default `IsPackable=true` was causing `dotnet pack` to also produce a stand-alone `ZeroAlloc.StateMachine.Generator` nupkg with the DLL under `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/` — Roslyn can't load it from there.

Setting `IsPackable=false` makes the bundled-only intent explicit and prevents the broken stand-alone package from leaking out to nuget.org. Consumers continue to get the generator via `ZeroAlloc.StateMachine` (one package, no change required).

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67 — the same root cause across the ecosystem.

## Test plan
- [ ] CI green
- [ ] `dotnet pack` only produces `ZeroAlloc.StateMachine.nupkg` (no `.Generator.nupkg`)
- [ ] The bundled generator DLL still appears at `analyzers/dotnet/cs/` inside the main package

🤖 Generated with [Claude Code](https://claude.com/claude-code)