### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,9 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.StateMachine.AotSmoke
+
+  api-compat:
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.StateMachine
+      csproj-path: src/ZeroAlloc.StateMachine/ZeroAlloc.StateMachine.csproj

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Explicitly elevate public-API analyzer diagnostics so the surface
+         stays locked even if TreatWarningsAsErrors is ever scoped down. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
 
     <!-- NuGet package metadata (shared across all packable projects) -->
     <Authors>Marcel Roozekrans</Authors>

--- a/src/ZeroAlloc.StateMachine/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.StateMachine/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.StateMachine/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.StateMachine/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.StateMachine/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.StateMachine/PublicAPI.Unshipped.txt
@@ -1,1 +1,21 @@
 #nullable enable
+ZeroAlloc.StateMachine.StateMachineAttribute
+ZeroAlloc.StateMachine.StateMachineAttribute.Concurrent.get -> bool
+ZeroAlloc.StateMachine.StateMachineAttribute.Concurrent.init -> void
+ZeroAlloc.StateMachine.StateMachineAttribute.InitialState.get -> string!
+ZeroAlloc.StateMachine.StateMachineAttribute.InitialState.init -> void
+ZeroAlloc.StateMachine.StateMachineAttribute.StateMachineAttribute() -> void
+ZeroAlloc.StateMachine.TerminalAttribute<TState>
+ZeroAlloc.StateMachine.TerminalAttribute<TState>.State.get -> TState
+ZeroAlloc.StateMachine.TerminalAttribute<TState>.State.init -> void
+ZeroAlloc.StateMachine.TerminalAttribute<TState>.TerminalAttribute() -> void
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.From.get -> TState
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.From.init -> void
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.On.get -> TTrigger
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.On.init -> void
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.To.get -> TState
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.To.init -> void
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.TransitionAttribute() -> void
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.When.get -> bool
+ZeroAlloc.StateMachine.TransitionAttribute<TState, TTrigger>.When.init -> void

--- a/src/ZeroAlloc.StateMachine/ZeroAlloc.StateMachine.csproj
+++ b/src/ZeroAlloc.StateMachine/ZeroAlloc.StateMachine.csproj
@@ -14,6 +14,15 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
   <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">


### PR DESCRIPTION
## Summary

- Adds `Microsoft.CodeAnalysis.PublicApiAnalyzers` (4.14.0) to the runtime project (`src/ZeroAlloc.StateMachine`) with `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` tracking files. Generator project intentionally excluded.
- Captures the current 1.0.x public surface (20 symbols — three attribute types: `StateMachineAttribute`, `TerminalAttribute<TState>`, `TransitionAttribute<TState, TTrigger>`) into `PublicAPI.Unshipped.txt` so RS0016 (undeclared) / RS0017 (removed) now break the build on any unintended surface change.
- Promotes `RS0016` / `RS0017` to errors via `Directory.Build.props` (in addition to the repo's existing `TreatWarningsAsErrors=true`, so the gate survives any future scoping of TWAE).
- Wires Phase B fan-out: a new `api-compat` job in `.github/workflows/ci.yml` consuming the org reusable workflow at `ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main`, comparing each PR's public surface against the package on nuget.org.

Sibling PRs in the public-API gating fan-out:
- ZeroAlloc-Net/ZeroAlloc.Authorization#5
- ZeroAlloc-Net/ZeroAlloc.AsyncEvents#47
- ZeroAlloc-Net/ZeroAlloc.Notify#43
- ZeroAlloc-Net/ZeroAlloc.Telemetry#19
- ZeroAlloc-Net/ZeroAlloc.ValueObjects#38
- ZeroAlloc-Net/ZeroAlloc.Outbox#44
- ZeroAlloc-Net/ZeroAlloc.Scheduling#44
- ZeroAlloc-Net/ZeroAlloc.Resilience#26

## Test plan

- [x] `dotnet build src/ZeroAlloc.StateMachine -c Release` clean (0 warnings, 0 errors across net8/net9/net10)
- [x] `dotnet test ZeroAlloc.StateMachine.slnx -c Release` passes (10 runtime + 9 generator tests)
- [x] Local rebuild after baselining yields 0 RS0016
- [ ] CI `api-compat` job succeeds on this PR (validates baseline matches the nuget.org 1.0.x surface)
- [ ] CI `build` + `aot-smoke` jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)