### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Removes `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`. These flags only apply to pre-1.0 packages — they demote `feat!`/`BREAKING CHANGE` from major to minor and `feat` from minor to patch.

This package is at **1.1.0**, so the flags would silently produce SemVer-violating releases on the next `feat!` or `feat` commit.

Same defect class as the recent ZeroAlloc.Mediator fix (Pattern C).

## Changes
- `release-please-config.json`: removed two boolean flags. Everything else preserved.

## Test plan
- [ ] CI passes
- [ ] Verify next release-please run computes the correct bump per Conventional Commits semantics (no demotion)